### PR TITLE
use this one - add hint: " " to get rid of the confusing placeholder text

### DIFF
--- a/docassemble/RFApackage/data/questions/RFApackage.yml
+++ b/docassemble/RFApackage/data/questions/RFApackage.yml
@@ -1,3 +1,4 @@
+#For al_international_phone, Suffolk folks figured out I can add hint: " " to get rid of the weird placeholder text
 
 ---
 include:
@@ -675,9 +676,11 @@ subquestion: |
 fields:  
   - Phone number: users[0].phone_number
     datatype: al_international_phone
+    hint: " "
     required: False
   - Work number: users1_work_phone_number
     datatype: al_international_phone
+    hint: " "
     required: False
   - Email: users[0].email    
     datatype: email
@@ -929,15 +932,19 @@ subquestion: |
 fields:  
   - Home phone: other_parties[0].phone_number
     datatype: al_international_phone
+    hint: " "
     required: False
   - Cell phone: other_parties[0].mobile_number
     datatype: al_international_phone
+    hint: " "
     required: False
   - Work phone: other_parties1_work_phone_number
     datatype: al_international_phone
+    hint: " "
     required: False
   - Other phone: other_parties1_other_phone_number
     datatype: al_international_phone
+    hint: " "
     required: False    
 ---
 id: What happened most recently
@@ -1866,6 +1873,7 @@ fields:
         users[0].phone_number or users1_work_phone_number
   - Notification phone number: users1_notify_phone_number_other_input
     datatype: al_international_phone
+    hint: " "
     maxlength: 45
     required: False
     show if: notify_served


### PR DESCRIPTION
For al_international_phone, Suffolk folks figured out I can add hint: " " to get rid of the confusing placeholder text